### PR TITLE
Add throw stringified NSException from Obj-C and capture it in JSC

### DIFF
--- a/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
+++ b/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
@@ -1240,6 +1240,11 @@ jsi::Function JSCRuntime::createFunctionFromHostFunction(
         exceptionString += ex.what();
         *exception = makeError(rt, exceptionString);
         res = JSValueMakeUndefined(ctx);
+      } catch (const std::string &ex) {
+        std::string exceptionString("Exception in HostFunction: ");
+        exceptionString += ex;
+        *exception = makeError(rt, exceptionString);
+        res = JSValueMakeUndefined(ctx);
       } catch (...) {
         std::string exceptionString("Exception in HostFunction: <unknown>");
         *exception = makeError(rt, exceptionString);

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
@@ -468,7 +468,15 @@ jsi::Value JavaTurboModule::invokeJavaMethod(
       } else {
         TMPL::asyncMethodCallFail(moduleName, methodName);
       }
-      throw;
+      auto exception = std::current_exception();
+      auto throwable = facebook::jni::getJavaExceptionForCppException(exception);
+      auto stackTrace = throwable->getStackTrace();
+      std::string stackTraceStr = throwable->toString() + '\n';
+      for (int i = 0; i < stackTrace->size(); ++i) {
+        auto frame = stackTrace->getElement(i);
+        stackTraceStr += frame->toString() + '\n';
+      }
+      throw std::runtime_error(stackTraceStr);
     }
   };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This is a POC of how platform and native exceptions could be passed to the JS layer to get the full stack trace from a JS call to the platform stack trace where an error occurred. 

At the moment the stack trace is passed in the JS Error description as a string. For the future structured platform-agnostic approach would be better for further processing of the error.

Similar structure to https://develop.sentry.dev/sdk/event-payloads/stacktrace

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL][ADDED] - TBA

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

| iOS | Android |
|--------|--------|
| ![Screenshot 2023-04-13 at 15 00 54](https://user-images.githubusercontent.com/31292499/231766707-d81daeaa-10f9-4904-9b70-18335eddd359.png) | ![Screenshot 2023-04-13 at 15 01 10](https://user-images.githubusercontent.com/31292499/231766737-4eaacc25-33b8-4ce7-b475-887fdd0e8123.png) |


